### PR TITLE
Added composite query 

### DIFF
--- a/examples/sampling_examples/daily-transaction-count.sql
+++ b/examples/sampling_examples/daily-transaction-count.sql
@@ -1,0 +1,18 @@
+WITH
+  daily_transactions AS (
+  SELECT
+    DATE(block_timestamp) AS date,
+    COUNT(*) AS count
+  FROM
+    `testsolana_1.Transactions`
+  GROUP BY
+    date )
+SELECT
+  DATE_TRUNC(date, WEEK) AS week,
+  CAST(AVG(count) AS INT64) AS count
+FROM
+  daily_transactions
+GROUP BY
+  week
+ORDER BY
+  week

--- a/examples/sampling_examples/get-highest-throughput.sql
+++ b/examples/sampling_examples/get-highest-throughput.sql
@@ -1,0 +1,13 @@
+SELECT
+  'solana' AS chain,
+  COUNT(*) / (24 * 60 * 60 / COUNT(*) OVER (PARTITION BY DATE(block_timestamp))) AS throughput,
+  block_timestamp AS time
+FROM
+  `testsolana_1.Transactions` AS transactions
+GROUP BY
+  transactions.block_slot,
+  transactions.block_timestamp
+ORDER BY
+  throughput DESC
+LIMIT
+  1

--- a/examples/sampling_examples/top-1000-fee-spenders-last-24-hours.sql
+++ b/examples/sampling_examples/top-1000-fee-spenders-last-24-hours.sql
@@ -1,0 +1,53 @@
+WITH
+  GetTopFeeSpenders AS (
+    SELECT
+      t.fee,
+      a.pubkey AS account_pubkey,
+      t.block_timestamp
+    FROM
+      testsolana_1.Transactions t
+      CROSS JOIN 
+        UNNEST (t.accounts) AS a
+  ),
+  AggregatedData AS (
+    SELECT
+      account_pubkey,
+      SUM(
+        CASE
+          WHEN block_timestamp >= TIMESTAMP_SUB (CURRENT_TIMESTAMP(), INTERVAL 1 HOUR) 
+          THEN fee
+          ELSE 0
+        END
+      ) AS total_fee_1_hour,
+      SUM(
+        CASE
+          WHEN block_timestamp >= TIMESTAMP_SUB (CURRENT_TIMESTAMP(), INTERVAL 24 HOUR) 
+          THEN fee
+          ELSE 0
+        END
+      ) AS total_fee_24_hours,
+      COUNT(*) AS total_transactions_1_hour,
+      COUNT(
+        CASE
+          WHEN block_timestamp >= TIMESTAMP_SUB (CURRENT_TIMESTAMP(), INTERVAL 24 HOUR) 
+          THEN 1
+        END
+      ) AS total_transactions_24_hours
+    FROM
+      GetTopFeeSpenders
+    GROUP BY
+      account_pubkey
+  )
+SELECT
+  account_pubkey,
+  total_fee_1_hour,
+  total_fee_24_hours,
+  total_transactions_1_hour,
+  total_transactions_24_hours
+FROM
+  AggregatedData
+ORDER BY
+  total_fee_1_hour DESC,
+  total_fee_24_hours DESC
+LIMIT
+  1000;

--- a/examples/sampling_examples/top-1000-lamport-holders.sql
+++ b/examples/sampling_examples/top-1000-lamport-holders.sql
@@ -1,0 +1,8 @@
+SELECT
+  *
+FROM
+  testsolana_1.Accounts
+ORDER BY
+  lamports DESC
+LIMIT
+  1000;

--- a/examples/testing_examples/get-block-info-at-80000000.sql
+++ b/examples/testing_examples/get-block-info-at-80000000.sql
@@ -1,0 +1,68 @@
+WITH BlockInfo AS (
+  SELECT
+    slot,
+    block_timestamp,
+    block_hash,
+    leader,
+    leader_reward,
+    transaction_count,
+    previous_block_hash
+  FROM
+    testsolana_1.Blocks
+  WHERE
+    slot = 80000000
+    AND block_timestamp > '2021-01-01'
+),
+TransactionInfo AS (
+  SELECT
+    signature,
+    block_slot,
+    block_timestamp AS transaction_block_timestamp,
+    log_messages,
+    a.pubkey,
+    fee
+  FROM
+    testsolana_1.Transactions
+  CROSS JOIN
+    UNNEST(accounts) AS a
+  WHERE
+    block_slot = 80000000
+    AND block_timestamp > '2021-01-01'
+),
+BlockRewards AS (
+  SELECT
+    block_slot,
+    commission,
+    lamports,
+    pubkey,
+    reward_type
+  FROM
+    testsolana_1.`Block Rewards`
+  WHERE
+    block_slot = 80000000
+    AND block_timestamp > '2021-01-01'
+)
+SELECT
+  BlockInfo.slot,
+  BlockInfo.block_timestamp,
+  BlockInfo.block_hash,
+  BlockInfo.leader,
+  BlockInfo.leader_reward,
+  BlockInfo.transaction_count,
+  BlockInfo.previous_block_hash,
+  TransactionInfo.signature,
+  TransactionInfo.block_slot AS transaction_block_slot,
+  TransactionInfo.transaction_block_timestamp,
+  TransactionInfo.log_messages,
+  TransactionInfo.pubkey AS account_pubkey,
+  TransactionInfo.fee,
+  BlockRewards.commission,
+  BlockRewards.lamports,
+  BlockRewards.pubkey AS reward_pubkey,
+  BlockRewards.reward_type
+FROM
+  BlockInfo
+LEFT JOIN
+  TransactionInfo ON BlockInfo.slot = TransactionInfo.block_slot
+LEFT JOIN
+  BlockRewards ON BlockInfo.slot = BlockRewards.block_slot;

--- a/examples/testing_examples/get-transaction-info-last-24h.sql
+++ b/examples/testing_examples/get-transaction-info-last-24h.sql
@@ -1,0 +1,28 @@
+SELECT
+  (
+    SELECT
+      COUNT(*)
+    FROM
+      testsolana_1.Transactions
+    WHERE
+      block_timestamp >= TIMESTAMP_SUB (CURRENT_TIMESTAMP(), INTERVAL 24 HOUR)
+      AND block_timestamp <= CURRENT_TIMESTAMP()
+  ) AS transaction_count,
+  (
+    SELECT
+      SUM(fee)
+    FROM
+      testsolana_1.Transactions
+    WHERE
+      block_timestamp >= TIMESTAMP_SUB (CURRENT_TIMESTAMP(), INTERVAL 24 HOUR)
+      AND block_timestamp <= CURRENT_TIMESTAMP()
+  ) AS total_fees,
+  (
+    SELECT
+      AVG(fee)
+    FROM
+      testsolana_1.Transactions
+    WHERE
+      block_timestamp >= TIMESTAMP_SUB (CURRENT_TIMESTAMP(), INTERVAL 24 HOUR)
+      AND block_timestamp <= CURRENT_TIMESTAMP()
+  ) AS average_fee;


### PR DESCRIPTION
> We are being asked by Devan to put together scripts to sanity check our sets.  Currently, the process is to essentially recreate the block page we see on solscan (or other explorer) like this, https://solscan.io/block/80000000.  We have some basic queries already written so effectively merging these into a JOIN action as a composite.sql file in this directory: https://github.com/BCWResearch/solana-etl-query-cookbook/tree/dev/examples/testing_examples.

**BlockInfo** (`/examples/testing_examples/get-block-info-at-80000000.sql`)

*Performance*: 6.43 TB when run.

**TransactionInfo** (24h) (`/examples/testing_examples/get-transaction-info-last-24h.sql`)

*Performance*: 783.19 MB when run.

**DailyTransactionCount** (`/examples/sampling_examples/daily-transaction-count.sql`)

*Performance*: 170.93 GB when run.

**HighestThroughput** (`/examples/sampling_examples/get-highest-throughput.sql`)

*Performance*: 341.94 GB when run.

**Top1000FeeSpenders** (24h) (`/examples/sampling_examples/top-1000-fee-spenders-last-24-hours.sql`)

*Performance*: 5.73 TB when run.

**Top1000LamportHolders** (`/examples/sampling_examples/top-1000-lamport-holders.sql`)

*Performance*: 33.14 GB when run.
